### PR TITLE
Add OAuth2 Authorization Server

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ const indexRouter = require('./routes/index');
 const registerRouter = require('./routes/register');
 const loginRouter = require('./routes/login');
 const logoutRouter = require('./routes/logout');
+const accountRouter = require('./routes/account');
 
 const app = express();
 
@@ -34,7 +35,7 @@ app.use(cookieParser());
 // Manage sessions using express-session
 // TODO: hardening configuration, such as https only cookies
 app.use(require('express-session')({
-  secret: 'something',
+  secret: 'something to replace later',
   resave: false,
   saveUninitialized: false,
 }));
@@ -51,8 +52,9 @@ app.use('/register', registerRouter);
 app.use('/login', loginRouter);
 app.use('/logout', logoutRouter);
 
+app.use('/account', accountRouter);
 
-// Set up passport strategy
+// Set up passport strategy for local auth
 const Account = require('./models/account');
 passport.use(new LocalStrategy(Account.authenticate()));
 passport.serializeUser(Account.serializeUser());

--- a/app.js
+++ b/app.js
@@ -14,6 +14,10 @@ const registerRouter = require('./routes/register');
 const loginRouter = require('./routes/login');
 const logoutRouter = require('./routes/logout');
 const accountRouter = require('./routes/account');
+const oauth2Router = require('./routes/oauth');
+const dialogRouter = require('./routes/dialog');
+const apiRouter = require('./routes/api');
+const authRouter = require('./routes/auth');
 
 const app = express();
 
@@ -46,13 +50,8 @@ app.use(passport.session());
 
 app.use(express.static(path.join(__dirname, 'public')));
 
-// Router routes
-app.use('/', indexRouter);
-app.use('/register', registerRouter);
-app.use('/login', loginRouter);
-app.use('/logout', logoutRouter);
-
-app.use('/account', accountRouter);
+// Set up the mongoose connection
+mongoose.connect('mongodb://localhost/auth-exercise', {'useNewUrlParser': true});
 
 // Set up passport strategy for local auth
 const Account = require('./models/account');
@@ -60,8 +59,20 @@ passport.use(new LocalStrategy(Account.authenticate()));
 passport.serializeUser(Account.serializeUser());
 passport.deserializeUser(Account.deserializeUser());
 
-// Set up the mongoose connection
-mongoose.connect('mongodb://localhost/auth-exercise', {'useNewUrlParser': true});
+// OAuth 2 Passport Settings
+require('./auth/oauth2');
+
+// Router routes
+app.use('/', indexRouter);
+app.use('/register', registerRouter);
+app.use('/login', loginRouter);
+app.use('/logout', logoutRouter);
+app.use('/account', accountRouter);
+app.use('/dialog', dialogRouter);
+app.use('/oauth', oauth2Router);
+app.use('/api', apiRouter);
+app.use('/auth', authRouter);
+
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/auth/oauth2.js
+++ b/auth/oauth2.js
@@ -1,0 +1,45 @@
+const passport = require('passport');
+const BasicStrategy = require('passport-http').BasicStrategy;
+const BearerStrategy = require('passport-http-bearer').Strategy;
+const db = require('../db');
+const Account = require('../models/account.js');
+
+/**
+ * This function verifies that a client id and client secret
+ * are registered in our database.  
+ * @param {string} clientId - the client id
+ * @param {string} clientSecret - the client secret
+ * @param {done} done - the done callback
+ * */
+function verifyClient(clientId, clientSecret, done) {
+  // TODO: make this mongo db
+  db.clients.findByClientId(clientId, (error, client) => {
+    if (error) return done(error);
+    if (!client) return done(null, false);
+    if (client.clientSecret !== clientSecret) return done(null, false);
+    return done(null, client);
+  });
+}
+
+// Use this strategy to protect the token endpoint using the HTTP Basic
+// scheme to authenticate using the client secret and client id
+passport.use(new BasicStrategy(verifyClient));
+
+// This strategy is registered to be used on api endpoints that we want
+// to protect using bearer tokens. The strategy checks that the acess
+// tokens are found in our database and that the account exists that
+// authorized the bearer token.
+passport.use(new BearerStrategy(
+    (accessToken, done) => {
+      db.accessTokens.find(accessToken, (error, token) => {
+        if (error) return done(error);
+        if (!token) return done(null, false);
+        Account.findById(token.userId, (error, user) => {
+          if (error) return done(error);
+          if (!user) return done(null, false);
+          // To keep this example simple, restricted scopes are not implemented,
+          // and this is just for illustrative purposes.
+          done(null, user, {scope: '*'});
+        });
+      });
+    }));

--- a/auth/oauth2server.js
+++ b/auth/oauth2server.js
@@ -1,0 +1,54 @@
+const oauth2orize = require('oauth2orize');
+const db = require('../db');
+const utils = require('../utils');
+
+const server = oauth2orize.createServer();
+
+// Serialize on the client id
+server.serializeClient((client, done) => done(null, client.id));
+
+// Deserialize by finding the client id in the client db
+server.deserializeClient((id, done) => {
+  db.clients.findById(id, (error, client) => {
+    if (error) return done(error);
+    return done(null, client);
+  });
+});
+
+// Register the authorization code grant type for the authentication code flow.
+server.grant(oauth2orize.grant.code((client, redirectUri, user, ares, done) => {
+  // TODO: Replace this out with a more secure implementation
+  const code = utils.getUid(16);
+  db.authorizationCodes.save(code, client.id, redirectUri, user.id, (error) => {
+    if (error) return done(error);
+    return done(null, code);
+  });
+}));
+
+// This function exchanges authorization codes for access tokens which then
+// can be utilize by protected resources that require bearer tokens.
+server.exchange(oauth2orize.exchange.code((client, code, redirectUri, done) => {
+  db.authorizationCodes.find(code, (error, authCode) => {
+    if (error) return done(error);
+
+    // Validate that our client Id matches that of the auth code
+    if (client.id !== authCode.clientId) return done(null, false);
+
+    // Make sure that the redirect URI is what was provided in the
+    // Authorize call.
+    if (redirectUri !== authCode.redirectUri) return done(null, false);
+
+    // Generate an access token
+    // TODO: replace this with a more secure function
+    const token = utils.getUid(256);
+
+    // Save the access token so that our bearer strategy can verify it
+    // TODO: Token expiry
+    db.accessTokens.save(token, authCode.userId, authCode.clientId, (error) => {
+      if (error) return done(error);
+      return done(null, token);
+    });
+  });
+}));
+
+module.exports = server;

--- a/bin/www
+++ b/bin/www
@@ -16,8 +16,8 @@ const sslCert = fs.readFileSync('sslcert/certificate.pem');
 // Describe options to the https server
 const sslOptions = {
   key: sslkey,
-  cert: sslCert
-}
+  cert: sslCert,
+};
 
 /**
  * Get port from environment and store in Express.

--- a/db/access_tokens.js
+++ b/db/access_tokens.js
@@ -1,0 +1,22 @@
+// The following code was borrowed from an example by gerges-beshay
+// here: https://github.com/gerges-beshay/oauth2orize-examples
+// I plan on replacing this out in favor of a mongo db collection.
+// TODO: make mongo db collection
+const tokens = {};
+
+module.exports.find = (key, done) => {
+  if (tokens[key]) return done(null, tokens[key]);
+  return done(new Error('Token Not Found'));
+};
+
+module.exports.findByUserIdAndClientId = (userId, clientId, done) => {
+  for (const token in tokens) {
+    if (tokens[token].userId === userId && tokens[token].clientId === clientId) return done(null, token);
+  }
+  return done(new Error('Token Not Found'));
+};
+
+module.exports.save = (token, userId, clientId, done) => {
+  tokens[token] = { userId, clientId };
+  done();
+};

--- a/db/authorization_codes.js
+++ b/db/authorization_codes.js
@@ -1,0 +1,17 @@
+// The following code was borrowed from an example by gerges-beshay
+// here: https://github.com/gerges-beshay/oauth2orize-examples
+// I plan on replacing this out in favor of a mongo db collection.
+// TODO: make mongo db collection
+const codes = {};
+
+module.exports.find = (key, done) => {
+  if (codes[key]) return done(null, codes[key]);
+  return done(new Error('Code Not Found'));
+};
+
+// TODO: Make the max life of authorization codes 10 minutes per
+// RFC 6749.
+module.exports.save = (code, clientId, redirectUri, userId, done) => {
+  codes[code] = {clientId, redirectUri, userId};
+  done();
+};

--- a/db/clients.js
+++ b/db/clients.js
@@ -1,0 +1,23 @@
+// The following code was borrowed from an example by gerges-beshay
+// here: https://github.com/gerges-beshay/oauth2orize-examples
+// I plan on replacing this out in favor of a mongo db collection.
+// TODO: make mongo db collection
+
+const clients = [
+  {id: '1', name: 'Client1', clientId: 'client1', clientSecret: 'secret1', redirectUri: 'https://www.getpostman.com/oauth2/callback', isTrusted: false},
+  {id: '2', name: 'Client2', clientId: 'client2', clientSecret: 'secret2', redirectUri: 'https://www.getpostman.com/oauth2/callback', isTrusted: true},
+];
+
+module.exports.findById = (id, done) => {
+  for (let i = 0, len = clients.length; i < len; i++) {
+    if (clients[i].id === id) return done(null, clients[i]);
+  }
+  return done(new Error('Client Not Found'));
+};
+
+module.exports.findByClientId = (clientId, done) => {
+  for (let i = 0, len = clients.length; i < len; i++) {
+    if (clients[i].clientId === clientId) return done(null, clients[i]);
+  }
+  return done(new Error('Client Not Found'));
+};

--- a/db/index.js
+++ b/db/index.js
@@ -1,0 +1,14 @@
+// The following code was borrowed from an example by gerges-beshay
+// here: https://github.com/gerges-beshay/oauth2orize-examples
+// I plan on replacing this out in favor of a mongo db collection.
+// TODO: make mongo db collection
+
+const clients = require('./clients');
+const accessTokens = require('./access_tokens');
+const authorizationCodes = require('./authorization_codes');
+
+module.exports = {
+  clients,
+  accessTokens,
+  authorizationCodes,
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "devmode": "DEBUG=jmoss-auth-exercise:* nodemon start"
+    "devmode": "DEBUG=jmoss-auth-exercise:*,oauth2orize nodemon start"
   },
   "dependencies": {
     "acorn": "^6.0.4",
@@ -21,6 +21,8 @@
     "oauth2orize": "^1.11.0",
     "passport": "^0.4.0",
     "passport-github2": "^0.1.11",
+    "passport-http": "^0.3.0",
+    "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",
     "passport-local-mongoose": "^5.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "acorn": "^6.0.4",
+    "connect-ensure-login": "^0.1.1",
     "cookie-parser": "^1.4.3",
     "debug": "^2.6.9",
     "express": "^4.16.0",
@@ -17,6 +18,7 @@
     "jade": "^1.11.0",
     "mongoose": "^5.3.12",
     "morgan": "^1.9.0",
+    "oauth2orize": "^1.11.0",
     "passport": "^0.4.0",
     "passport-github2": "^0.1.11",
     "passport-local": "^1.0.0",

--- a/routes/account.js
+++ b/routes/account.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const ensureLoggedIn = require('connect-ensure-login').ensureLoggedIn;
+
+router.get('/', ensureLoggedIn('/login'), function(req, res) {
+  res.render('account', {user: req.user});
+});
+
+module.exports = router;

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const passport = require('passport');
+const router = express.Router();
+
+// This is the user info endpoint protected by access tokens
+router.get('/userinfo', passport.authenticate('bearer', {session: false, failureRedirect: '/login'}),
+    function(req, res) {
+      res.json({user_id: req.user_id});
+    });
+
+module.exports = router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+const passportGithub = require('../auth/github');
+
+// Use the github passport strategy
+router.get('/github', passportGithub.authenticate('github', {scope: ['user:email']}));
+
+// Handler for the callback from OAuth
+router.get('/github/callback',
+    passportGithub.authenticate('github', {failureRedirect: '/error'}),
+    function(req, res) {
+    // For now we just redirect to the main page
+      res.redirect('/');
+    });
+
+module.exports = router;

--- a/routes/dialog.js
+++ b/routes/dialog.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const router = express.Router();
+const login = require('connect-ensure-login');
+const server = require('../auth/oauth2server');
+const db = require('../db');
+
+// The user authorization endpoint
+router.get('/authorize',
+    login.ensureLoggedIn(),
+    server.authorization((clientId, redirectUri, done) => {
+      /* By the RFC 6749
+      the request must have a response_type, client_id. State,
+      scope and redirect_uri are optional but highly recommended.
+      Most of this is handled through the server.authorization
+      middleware*/
+      db.clients.findByClientId(clientId, (error, client) => {
+        if (error) return done(error);
+        // We need to validate that the redirect uri is the same
+        // as what we've registered in our application
+        if (client.redirectUri !== redirectUri) return done(error);
+
+        return done(null, client, redirectUri);
+      });
+    }, (client, user, done) => {
+    // Check if grant request qualifies for immediate approval
+
+      // If a client is trusted already, then we can go ahead and approve
+      // the request.
+      if (client.isTrusted) return done(null, true);
+
+      db.accessTokens.findByUserIdAndClientId(user.id, client.clientId, (error, token) => {
+        // Check to see if there is already an access token associated with this UserId
+        // and ClientId
+        if (token) return done(null, true);
+
+        // If the user does not already have an access token, they will need to give
+        // their consent.
+        return done(null, false);
+      });
+    }),
+    function(request, response) {
+      response.render('dialog', {transactionId: request.oauth2.transactionID, user: request.user, client: request.oauth2.client});
+    });
+
+// Process the allow or deny, triggering the above middleware to send
+// the response to the user.
+router.post('/authorize/decision',
+    login.ensureLoggedIn(),
+    server.decision()
+);
+
+module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,21 +1,8 @@
 const express = require('express');
 const router = express.Router();
-const passportGithub = require('../auth/github');
 
 router.get('/', function(req, res) {
   res.render('index', {user: req.user});
 });
-
-// TODO: Move routes to their own js file
-// Use the github passport strategy
-router.get('/auth/github', passportGithub.authenticate('github', {scope: ['user:email']}));
-
-// Handler for the callback from OAuth
-router.get('/auth/github/callback',
-    passportGithub.authenticate('github', {failureRedirect: '/error'}),
-    function(req, res) {
-    // For now we just redirect to the main page
-      res.redirect('/');
-    });
 
 module.exports = router;

--- a/routes/login.js
+++ b/routes/login.js
@@ -7,9 +7,6 @@ router.get('/', function(req, res) {
 });
 
 router.post('/', passport.authenticate('local',
-  {successReturnToOrRedirect: '/', failureRedirect: '/login'}),
-  function(req, res) {
-    res.redirect('/');
-});
+    {successReturnToOrRedirect: '/', failureRedirect: '/login'}));
 
 module.exports = router;

--- a/routes/login.js
+++ b/routes/login.js
@@ -6,8 +6,10 @@ router.get('/', function(req, res) {
   res.render('login', {user: req.user});
 });
 
-router.post('/', passport.authenticate('local'), function(req, res) {
-  res.redirect('/');
+router.post('/', passport.authenticate('local',
+  {successReturnToOrRedirect: '/', failureRedirect: '/login'}),
+  function(req, res) {
+    res.redirect('/');
 });
 
 module.exports = router;

--- a/routes/oauth.js
+++ b/routes/oauth.js
@@ -1,0 +1,17 @@
+
+const express = require('express');
+const router = express.Router();
+const passport = require('passport');
+const server = require('../auth/oauth2server');
+
+// This is the token endpoint where we exchange an authorization
+// code for an access token that can be used for protected
+// access token endpoints. Right now we only support basic 
+// authentication with the client_id and client_secret.
+router.post('/token',
+    passport.authenticate('basic', {session: false}),
+    server.token(),
+    server.errorHandler()
+);
+
+module.exports = router;

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,36 @@
+// The following code was borrowed from an example by gerges-beshay
+// here: https://github.com/gerges-beshay/oauth2orize-examples
+// I plan on replacing this out in favor of a more secure way to generate
+// the Uid.
+// TODO: make a secure random number.
+
+/**
+ * Return a unique identifier with the given `len`.
+ *
+ * @param {Number} length
+ * @return {String}
+ * @api private
+ */
+module.exports.getUid = function(length) {
+  let uid = '';
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charsLength = chars.length;
+
+  for (let i = 0; i < length; ++i) {
+    uid += chars[getRandomInt(0, charsLength - 1)];
+  }
+
+  return uid;
+};
+
+/**
+ * Return a random int, used by `utils.getUid()`.
+ *
+ * @param {Number} min
+ * @param {Number} max
+ * @return {Number}
+ * @api private
+ */
+function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}

--- a/views/account.jade
+++ b/views/account.jade
@@ -1,0 +1,10 @@
+extends layout
+
+block content
+  p.lead Account Page
+  if (user)
+    if (user.name)
+      p You are currently logged in as #{user.name}
+    else 
+      p You are currently logged in as #{user.username}
+    a(href="/logout") Logout

--- a/views/dialog.jade
+++ b/views/dialog.jade
@@ -1,0 +1,16 @@
+extends layout
+
+block content
+  p.lead #{client.name} is requesting access to your account.
+  p.lead #{transacton_id}
+  if (user)
+    if (user.name)
+      p You are currently logged in as #{user.name}
+    else 
+      p You are currently logged in as #{user.username}
+    p Do you approve their request?
+    form(action="/dialog/authorize/decision", method="post")
+        input.form-control(type="hidden", name="transaction_id", value="#{transactionId}")
+        .form-group
+            input.form-control(type='Submit', value='Allow', id="allow")
+            input.form-control(type='Submit', value="Deny", name='Cancel', id="deny")


### PR DESCRIPTION
This commit adds a basic Oauth2 Authorization Server and the
following features:
- Ability to gain an access token using the authorization code flow
- store and validate access tokens
- store and validate authorization codes
- present an approve/deny dialog for the user to provide consent
- skip the dialog if you've already approved consent
- adds the scaffoling of a userinfo api endpoint in order to test
that bearer tokens work

Tested by using postman
- For local auth, the "get access token" button

Tested manually
- Tested each endpoint through the authorization code flow with
both the github authentication and local authentication schemes.

Note, this is a large commit from a result of a rebase of a number
of smaller commits.

Fixes #1, Fixes #3, Fixes #4, Fixes #5 