### PR TITLE
Tighten up the session cookie requirements

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,12 @@ app.use(require('express-session')({
   secret: 'something to replace later',
   resave: false,
   saveUninitialized: false,
+  cookie: {
+    secure: true,
+    sameSite: true,
+    path: '/',
+    httpOnly: true,
+  },
 }));
 
 // Passport configuration


### PR DESCRIPTION
This commit adds additional protection from cookie by explicity
adding cookie attributes that include Secure:true, HostOnly:true,
HttpOnly:true, the path restricted to "/" and sameSite:"Strict".

It should be noted that the defaults for express.js are actually
all of the above, except the default for secure is false. By
defining these explicitly we can be reminded what they are set to.

Fixes #11 