### PR TITLE
Ensure state parameter is checked (github)

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,7 +44,10 @@ app.use(require('express-session')({
   saveUninitialized: false,
   cookie: {
     secure: true,
-    sameSite: true,
+    // Note sameSite lax is set here so that we can use the github
+    // social provider login via oauth and allow our sessions to
+    // propagate there and finish our authorization flow.
+    sameSite: 'Lax',
     path: '/',
     httpOnly: true,
   },

--- a/auth/github.js
+++ b/auth/github.js
@@ -9,6 +9,7 @@ passport.use(new GitHubStrategy({
   clientID: config.github.clientID,
   clientSecret: config.github.clientSecret,
   callbackURL: config.github.callbackURL,
+  state: true,
 },
 function(accessToken, refreshToken, profile, done) {
   // Use the github profile id for the search

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -7,10 +7,7 @@ router.get('/github', passportGithub.authenticate('github', {scope: ['user:email
 
 // Handler for the callback from OAuth
 router.get('/github/callback',
-    passportGithub.authenticate('github', {failureRedirect: '/error'}),
-    function(req, res) {
-    // For now we just redirect to the main page
-      res.redirect('/');
-    });
+    passportGithub.authenticate('github',
+        {successReturnToOrRedirect: '/', failureRedirect: '/error'}));
 
 module.exports = router;


### PR DESCRIPTION
The previous implementation of the social login for github
did not include the state parameter, which certainly
could open us up to CSRF attacks.

The following commit sends the state option to the passport
session middleware to create state to verify. Also, after
tightening down the cookies and adding the state parameter,
I needed to lighten the sameSite requirement to lax in order
to allow session to flow back from github when we do
social auth.

Fixes #10 