### PR TITLE
Adds unique constraints to schema

### DIFF
--- a/models/account.js
+++ b/models/account.js
@@ -3,10 +3,10 @@ const Schema = mongoose.Schema;
 const passportLocalMongoose = require('passport-local-mongoose');
 
 const Account = new Schema({
-  username: String,
+  username: {type: String, unique: true},
   password: String,
   name: String,
-  githubId: String,
+  githubId: {type: String, unique: true},
 });
 
 // TODO: Add name to schema through the form using local auth


### PR DESCRIPTION
While the username was already set to a unique constraint using
the passport-local-mongoose plugin, the githubId was not set as
a unique constraint. Since I made the assumption that the githubId
was unique, I should constrain it as such.

This also makes the username a unique constraint explicitly, just
for clarity.

Fixes #20 